### PR TITLE
Match hook descriptions with existing conventions

### DIFF
--- a/check-broken-packages/check-broken-packages.hook
+++ b/check-broken-packages/check-broken-packages.hook
@@ -4,6 +4,6 @@ Type = Package
 Target = *
 
 [Action]
-Description = Checking for package with missing dependencies
+Description = Checking for package with missing dependencies...
 Exec = /usr/bin/check-broken-packages
 When = PostTransaction

--- a/pacdiff/pacdiff.hook
+++ b/pacdiff/pacdiff.hook
@@ -4,7 +4,7 @@ Type = Package
 Target = *
 
 [Action]
-Description = Reviewing .pacnew files
+Description = Reviewing .pacnew files...
 Exec = /usr/share/libalpm/scripts/pacdiff_delta
 When = PostTransaction
 Depends = diffutils

--- a/reflector/reflector.hook
+++ b/reflector/reflector.hook
@@ -4,7 +4,7 @@ Type = Package
 Target = pacman-mirrorlist
 
 [Action]
-Description = Updating pacman-mirrorlist with reflector
+Description = Updating pacman-mirrorlist with reflector...
 When = PostTransaction
 Depends = reflector
 Exec = /bin/bash -c 'systemctl start reflector; test -f /etc/pacman.d/mirrorlist.local && cat /etc/pacman.d/mirrorlist.local /etc/pacman.d/mirrorlist > /etc/pacman.d/mirrorlist.new && mv /etc/pacman.d/mirrorlist{.new,}; test -f /etc/pacman.d/mirrorlist.pacnew && mv -v /etc/pacman.d/mirrorlist.{pacnew,orig} || true'

--- a/sync/boot_sync.hook
+++ b/sync/boot_sync.hook
@@ -6,7 +6,7 @@ Type = Path
 Target = boot/*
 
 [Action]
-Description = Sync file system on /boot
+Description = Syncing file system on /boot...
 Exec = /usr/bin/sync -f /boot
 When = PostTransaction
 Depends = coreutils

--- a/sync/root_sync.hook
+++ b/sync/root_sync.hook
@@ -6,7 +6,7 @@ Type = Package
 Target = *
 
 [Action]
-Description = Sync file system on /
+Description = Syncing file system on /...
 Exec = /usr/bin/sync -f /
 When = PostTransaction
 Depends = coreutils

--- a/xmonad-recompile/xmonad-recompile.hook
+++ b/xmonad-recompile/xmonad-recompile.hook
@@ -5,6 +5,6 @@ Target=xmonad*
 Target=haskell*
 
 [Action]
-Description=Recompile Xmonad config
+Description=Recompiling Xmonad config...
 When=PostTransaction
 Exec=/usr/bin/bash -euc "command -v xmonad > /dev/null || exit 0; find /home -mindepth 1 -maxdepth 1 -type d -printf '%P\0' | xargs -0I'{}' su '{}' -c 'xmonad --recompile || true'"


### PR DESCRIPTION
  find /usr/share/libalpm/hooks -type f -exec grep Description {} \;

...most existing hooks have Descriptions that end with '...' and with
verbs ending with 'ing'.